### PR TITLE
Fix cron.go

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -1,88 +1,84 @@
 package simplecron
 
-import "time"
+import (
+    "sync"
+    "time"
+)
 
-/*
-    ___ _ __ ___  _ __
-   / __| '__/ _ \| '_ \
-  | (__| | | (_) | | | |
-   \___|_|  \___/|_| |_|
-*/
-
-// CronObject - cron object /ᐠ｡‸｡ᐟ\
 type CronObject struct {
-	timerTime time.Duration
-	callback  CronCallback
-	stopCh    chan struct{}
-	active    bool
-	paused    bool
+    timerTime time.Duration
+    callback  CronCallback
+    stopCh    chan struct{}
+    stopWG    sync.WaitGroup
+    active    bool
+    paused    bool
 }
 
-// NewCronHandler - create new cron
 func NewCronHandler(callback CronCallback, timerTime time.Duration) *CronObject {
-	return &CronObject{
-		timerTime: timerTime,
-		callback:  callback,
-		stopCh:    make(chan struct{}, 1),
-	}
+    return &CronObject{
+        timerTime: timerTime,
+        callback:  callback,
+        stopCh:    make(chan struct{}),
+        active:    false,
+        paused:    false,
+    }
 }
 
-// Stop cron
 func (c *CronObject) Stop() {
-	if c.active {
-		c.active = false
-		c.stopCh <- struct{}{}
-	}
+    if c.active {
+        c.active = false
+        close(c.stopCh)
+        c.stopWG.Wait()
+    }
 }
 
-// Pause cron event exec
-func (c *CronObject) Pause() {
-	c.paused = true
-}
-
-// IsPaused - check cron is paused status
-func (c *CronObject) IsPaused() bool {
-	return c.paused
-}
-
-// IsActive - check cron is not paused & is not stopped
-func (c *CronObject) IsActive() bool {
-	return !c.paused && c.active
-}
-
-// Resume cron event exec
-func (c *CronObject) Resume() {
-	c.paused = false
-}
-
-func (c *CronObject) awaitStop() {
-	<-c.stopCh
-}
-
-// CronCallback - cron callback /ᐠ｡‸｡ᐟ\
-type CronCallback func()
-
-// Run cron
 func (c *CronObject) Run(immediately ...bool) {
-	c.active = true
-	sleepAtStart := true
+    c.active = true
+    sleepAtStart := true
 
-	go c.awaitStop()
+    if len(immediately) > 0 && immediately[0] {
+        sleepAtStart = false
+    }
 
-	if len(immediately) > 0 && immediately[0] {
-		sleepAtStart = false
-	}
-	if sleepAtStart {
-		time.Sleep(c.timerTime)
-	}
+    c.stopWG.Add(1)
 
-	for c.active {
-		if !c.active {
-			break
-		}
-		if !c.paused {
-			c.callback()
-		}
-		time.Sleep(c.timerTime)
-	}
+    go func() {
+        defer c.stopWG.Done()
+
+        if sleepAtStart {
+            select {
+            case <-time.After(c.timerTime):
+            case <-c.stopCh:
+                return
+            }
+        }
+
+        for c.active {
+            if !c.paused {
+                c.callback()
+            }
+
+            select {
+            case <-time.After(c.timerTime):
+            case <-c.stopCh:
+                return
+            }
+        }
+    }()
+}
+
+func (c *CronObject) IsActive() bool {
+    return c.active && !c.paused
+}
+
+func (c *CronObject) IsPaused() bool {
+    return c.paused
+}
+
+func (c *CronObject) Pause() {
+    c.paused = true
+}
+
+func (c *CronObject) Resume() {
+    c.paused = false
 }


### PR DESCRIPTION
You should also change the `(w *RMQWorker) stopCron()` method. Since `CronObject.Stop()` now safely terminates the goroutine and properly closes the `stopCh` channel, you don't need to recreate the `stopCh` channel in the `stopCron()` method. 

Here's the updated `stopCron()` method:

```go
func (w *RMQWorker) stopCron() {
    if w.cronHandler != nil {
        w.cronHandler.Stop()
    }
}
```

This will make sure that `stopCh` channel is safely closed and the goroutine running the cron job is properly terminated. Please make sure to replace the cron handler object with the updated CronObject in the `runCron()` method:

```go
func (w *RMQWorker) runCron() {
    w.cronHandler = NewCronHandler(w.timeIsUp, w.data.WaitResponseTimeout)
    w.cronHandler.Run()
}
```

With this update, the potential goroutine leak should be addressed.